### PR TITLE
Add context menu for page

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -26,6 +26,6 @@
     "default_title": "Open In Incognito"
   },
   "permissions": [
-      "tabs"
+      "tabs", "contextMenus"
   ]
 }

--- a/src/bg/background.js
+++ b/src/bg/background.js
@@ -5,5 +5,18 @@ document.addEventListener('DOMContentLoaded', function() {
     chrome.windows.create({"url": tab.url, "incognito": true});
 
   });
+  
+  chrome.contextMenus.onClicked.addListener(function(info, tab) {
+	
+    chrome.windows.create({"url": tab.url, "incognito": true});
+  
+  });
 
+});
+
+
+chrome.contextMenus.create({
+  id: 'openInIncognito',
+  title: "Open In Incognito",
+  contexts: ['page'],
 });


### PR DESCRIPTION
Enables a context menu for page items that opens the current page in an
incognito tab. This allows the user to hide the button and keep a
clearer toolbar while still benefiting from the extension.